### PR TITLE
Optimize star creation on resize

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -25,11 +25,23 @@ function setCopyrightYear() {
   }
 }
 
-const debouncedCreateStars = debounce(createStars, 250);
+let usingMobileStars = window.innerWidth < 768;
+
+function handleResize() {
+  const shouldUseMobile = window.innerWidth < 768;
+  if (shouldUseMobile !== usingMobileStars) {
+    usingMobileStars = shouldUseMobile;
+    createStars();
+  }
+}
+
+const debouncedResize = debounce(handleResize, 250);
 
 window.addEventListener('load', () => {
   setCopyrightYear();
   createStars();
 });
 
-window.addEventListener('resize', debouncedCreateStars);
+window.addEventListener('resize', debouncedResize);
+
+export { debounce, handleResize };

--- a/tests/resizeHandler.test.js
+++ b/tests/resizeHandler.test.js
@@ -1,0 +1,49 @@
+import { JSDOM } from 'jsdom';
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../scripts/createStars.js', () => ({
+  createStars: jest.fn(),
+}));
+
+let handleResize;
+let createStars;
+
+beforeEach(async () => {
+  jest.resetModules();
+  const dom = new JSDOM(`<!DOCTYPE html><div id="star-container"></div>`);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.window.innerWidth = 500; // start mobile
+  ({ handleResize } = await import('../scripts/main.js'));
+  ({ createStars } = await import('../scripts/createStars.js'));
+  createStars.mockClear();
+});
+
+test('does not create stars when width remains mobile', () => {
+  window.innerWidth = 600;
+  handleResize();
+  expect(createStars).not.toHaveBeenCalled();
+});
+
+test('creates stars when switching from mobile to desktop', () => {
+  window.innerWidth = 800;
+  handleResize();
+  expect(createStars).toHaveBeenCalled();
+});
+
+test('creates stars when switching from desktop to mobile', async () => {
+  // Re-import with desktop width
+  jest.resetModules();
+  const dom = new JSDOM(`<!DOCTYPE html><div id="star-container"></div>`);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.window.innerWidth = 1000;
+  ({ handleResize } = await import('../scripts/main.js'));
+  ({ createStars } = await import('../scripts/createStars.js'));
+  createStars.mockClear();
+
+  window.innerWidth = 500;
+  handleResize();
+  expect(createStars).toHaveBeenCalled();
+});
+


### PR DESCRIPTION
## Summary
- track whether starfield is using mobile or desktop star count
- only recreate stars when resize crosses the 768px breakpoint
- export resize handler for testing
- test that stars aren't unnecessarily recreated

## Testing
- `npm test --silent` *(fails: jest not found)*