### PR TITLE
Add error handling test for createStars

### DIFF
--- a/tests/createStars.test.js
+++ b/tests/createStars.test.js
@@ -21,4 +21,17 @@ describe('createStars', () => {
     const container = document.getElementById('star-container');
     expect(container.children.length).toBe(1000);
   });
+
+  test('logs an error when star container is missing', () => {
+    const dom = new JSDOM(`<!DOCTYPE html>`);
+    global.document = dom.window.document;
+    global.window = dom.window;
+
+    const errorMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => createStars()).not.toThrow();
+    expect(errorMock).toHaveBeenCalledWith('Star container not found!');
+
+    errorMock.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- test createStars when container is missing

## Testing
- `npm test` *(fails: jest not found)*